### PR TITLE
added BeforePresentCalibrated timescale and other minor edits

### DIFF
--- a/vocabularies/trs.ttl
+++ b/vocabularies/trs.ttl
@@ -67,8 +67,9 @@ trs:BeforePresent
   a skos:Concept ;
   a time:TRS ;
   rdfs:seeAlso <https://en.wikipedia.org/wiki/Before_Present> ;
+  skos:broader trs:BeforePresent ;
   skos:inScheme <http://linked.data.gov.au/def/trs> ;
-  skos:definition "A time scale used mainly in archaeology, geology and other scientific disciplines to specify when events occurred in the past. Because the 'present' time changes, standard practice is to use 1 January 1950 as the commencement date (epoch) of the age scale"@en ;
+  skos:definition "A time scale used mainly in archaeology, geology and other scientific disciplines to specify when events occurred in the past. Usually used when carbon dating was the method used to determine the age. Because the 'present' time changes, standard practice is to use 1 January 1950 as the commencement date (epoch) of the age scale"@en ;
   skos:prefLabel "Before Present"@en ;
   skos:topConceptOf <http://linked.data.gov.au/def/trs> ;
 .
@@ -235,36 +236,38 @@ trs:UTCTime
   skos:prefLabel "Coordinated Universal Time"@en ;
   skos:topConceptOf <http://linked.data.gov.au/def/trs> ;
 .
-
 trs:ThousandsOfYearsAgo
   a skos:Concept ;
   a time:TRS ;
-  dct:source <https://www.bipm.org/en/bipm-services/timescales/> ;
-  skos:altLabel "ka"@en ;
   skos:broader trs:BeforePresent ;
   skos:inScheme <http://linked.data.gov.au/def/trs> ;
   skos:definition "Temporal position expressed numerically scaled in thousands of years increasing backwards relative to 1950. Calibration to 1950 not always significant or done, except when carbon dating methods are used."@en ;
   skos:prefLabel "Thousands of Years Ago"@en ;
 .
-
 trs:MillionsOfYearsAgo
   a skos:Concept ;
   a time:TRS ;
-  dct:source <https://www.bipm.org/en/bipm-services/timescales/> ;
   skos:altLabel "Ma"@en ;
   skos:broader trs:BeforePresent ;
   skos:inScheme <http://linked.data.gov.au/def/trs> ;
   skos:definition "Temporal position expressed numerically scaled in millions of years increasing backwards relative to 1950. Calibration to 1950 usually not significant or done."@en ;
   skos:prefLabel "Millions of Years Ago"@en ;
 .
-
 trs:BillionsOfYearsAgo
   a skos:Concept ;
   a time:TRS ;
-  dct:source <https://www.bipm.org/en/bipm-services/timescales/> ;
   skos:altLabel "Ga"@en ;
   skos:broader trs:BeforePresent ;
   skos:inScheme <http://linked.data.gov.au/def/trs> ;
   skos:definition "Temporal position expressed numerically scaled in billions of years increasing backwards relative to 1950. Calibration to 1950 usually not significant or performed."@en ;
   skos:prefLabel "Billions of Years Ago"@en ;
+.
+trs:BeforePresentCalibrated
+  a skos:Concept ;
+  a time:TRS ;
+  skos:altLabel "BP-Cal"@en ;
+  skos:broader trs:BeforePresentCalibrated ;
+  skos:inScheme <http://linked.data.gov.au/def/trs> ;
+  skos:definition "A time scale used mainly in archaeology, geology and other scientific disciplines to specify when events occurred in the past. Usually used when carbon dating was the method used to determine the age. Because the 'present' time changes, standard practice is to use 1 January 1950 as the commencement date (epoch) of the age scale. A calibrated mean the age has been adjusted to take into account the variation of the carbon 14 to carbon 12 ratio in the atmosphere through time."@en ;
+  skos:prefLabel "Calibrated Years Before Present"@en ;
 .


### PR DESCRIPTION
The expand for Before Present did not include "Before Present" so I added a skos:broader line to that entry. I hope that is correct. I think that the expand should also be labeled "Geologic and Archeologic Timescales" or something like that. I have never done a pull request before, so I hope this one comes through.